### PR TITLE
Upgrade issue template to Github Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,75 @@
+name: '🐛 Bug Report'
+description: 'Submit a bug report to help us improve'
+title: '🐛 Bug Report: '
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+  - type: textarea
+    id: steps-to-reproduce
+    validations:
+      required: true
+    attributes:
+      label: '👟 Reproduction steps'
+      description: 'How do you trigger this bug? Please walk us through it step by step.'
+      placeholder: 'When I ...'
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: '👍 Expected behavior'
+      description: 'What did you think would happen?'
+      placeholder: 'It should ...'
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: '👎 Actual Behavior'
+      description: 'What did actually happen? Add screenshots, if applicable.'
+      placeholder: 'It actually ...'
+  - type: dropdown
+    id: appwrite-version
+    attributes:
+      label: '🎲 Appwrite version'
+      description: 'What version of Appwrite are you running?'
+      options:
+        - Version 0.10.x
+        - Version 0.9.x
+        - Version 0.8.x
+        - Version 0.7.x
+        - Version 0.6.x
+        - Different version (specify in environment)
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: '💻 Operating system'
+      description: 'What OS is your server / device running on?'
+      options:
+        - Linux
+        - MacOS
+        - Windows
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: enviromnemt
+    validations:
+      required: false
+    attributes:
+      label: '🧱 Your Environment'
+      description: 'Is your environment customized in any way?'
+      placeholder: 'I use Cloudflare for ...'
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: '👀 Have you spent some time to check if this issue has been raised before?'
+      description: 'Have you Googled for a similar issue or checked our older issues for a similar bug?'
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -73,3 +73,10 @@ body:
       options:
         - label: "I checked and didn't find similar issue"
           required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: '🏢 Have you read the Code of Conduct?'
+      options:
+        - label: 'I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)'
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,33 @@
+name: '📚 Documentation'
+description: 'Report an issue related to documentation'
+title: '📚 Documentation: '
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our documentation update request form 🙏
+  - type: textarea
+    id: issue-description
+    validations:
+      required: true
+    attributes:
+      label: '💭 Description'
+      description: 'A clear and concise description of what the issue is.'
+      placeholder: 'Documentation should not ...'
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: '👀 Have you spent some time to check if this issue has been raised before?'
+      description: 'Have you Googled for a similar issue or checked our older issues for a similar bug?'
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      description: 'This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md).'
+      label: '🏢 Have you read the Code of Conduct?'
+      options:
+        - label: 'I read the Code of Conduct'
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out our documentation update request form 🙏
+        Thanks for taking the time to make our documentation better 🙏
   - type: textarea
     id: issue-description
     validations:
@@ -26,8 +26,7 @@ body:
   - type: checkboxes
     id: read-code-of-conduct
     attributes:
-      description: 'This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md).'
       label: '🏢 Have you read the Code of Conduct?'
       options:
-        - label: 'I read the Code of Conduct'
+        - label: 'I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)'
           required: true

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,33 @@
+name: 🚀 Feature
+description: 'Submit a proposal for a new feature'
+title: '🚀 Feature: '
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our feature request form 🙏
+  - type: textarea
+    id: feature-description
+    validations:
+      required: true
+    attributes:
+      label: '🔖 Feature description'
+      description: 'A clear and concise description of what the feature is.'
+      placeholder: 'You should add ...'
+  - type: textarea
+    id: pitch
+    validations:
+      required: true
+    attributes:
+      label: '🎤 Pitch'
+      description: 'Please explain why this feature should be implemented and how it would be used. Add examples, if applicable.'
+      placeholder: 'In my use-case, ...'
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: '👀 Have you spent some time to check if this issue has been raised before?'
+      description: 'Have you Googled for a similar issue or checked our older issues for a similar bug?'
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -31,3 +31,10 @@ body:
       options:
         - label: "I checked and didn't find similar issue"
           required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: '🏢 Have you read the Code of Conduct?'
+      options:
+        - label: 'I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)'
+          required: true


### PR DESCRIPTION
This PR resolves #10 

I have completed the following tasks:
 - [x] Fork & clone this repository
 - [x] Prepare bug report issue form in .github/ISSUE_TEMPLATE/bug.yaml
 - [x] Prepare documentation issue form in .github/ISSUE_TEMPLATE/documentation.yaml
 - [x] Prepare feature request issue form in .github/ISSUE_TEMPLATE/feature.yaml
 - [x] Push changes to master and test issue forms on your fork
 - [x] Submit pull request

@Meldiron Please review it and suggest the required changes